### PR TITLE
Dropdown.vue: Don't access items at negative indices

### DIFF
--- a/src/modules/Dropdown.vue
+++ b/src/modules/Dropdown.vue
@@ -401,6 +401,9 @@ Ignoring item: `, item)
                 return !Array.isArray(instance) && instance === Object(instance)
             },
             scrollIntoView(pos) {
+                if (pos < 0) {
+                    return
+                }
                 var el = this.$refs.items[pos]
                 var items = Math.floor(el.offsetParent.offsetHeight / el.offsetHeight)
                 var scrollFixer = pos - items;


### PR DESCRIPTION
I was having issues when doing the following on a 'selectable' dropdown:

- Populate a dropdown with items
- Select an item
- Change the items in the dropdown
- Click the dropdown to select it again

It would call `scrollIntoView(-1)`, because the `this.selected` item no longer existed in the current array of items.

I've added a clause to skip the scrolling if this occurs.